### PR TITLE
6.2.0 - Add `load_data_by_*`

### DIFF
--- a/root/mods-unpacked/Darkly77-ContentLoader/content_loader.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/content_loader.gd
@@ -61,7 +61,7 @@ func load_data(mod_data_path: String, mod_name: String = "UnspecifiedAuthor-Unsp
 
 	var mod_data = load(mod_data_path)
 
-	_add_mod_data(mod_data)
+	_add_mod_data(mod_data, mod_name)
 
 
 # Adds missing keys with empty arrays to a provided mod_data dictionary. This
@@ -85,7 +85,7 @@ func load_data_by_dictionary(mod_data_dict: Dictionary, mod_name: String = "Unsp
 		if not mod_data_dict.has(default_key):
 			mod_data_dict[default_key] = []
 
-	_add_mod_data(mod_data_dict)
+	_add_mod_data(mod_data_dict, mod_name)
 
 
 # Private

--- a/root/mods-unpacked/Darkly77-ContentLoader/content_loader.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/content_loader.gd
@@ -1,7 +1,6 @@
 class_name ContentLoader
 extends Node
 
-var ContentData = load("res://mods-unpacked/Darkly77-ContentLoader/content_data.gd").new()
 const CLOADER_LOG = "Darkly77-ContentLoader"
 
 # Content added via ContentLoader is added via `_install_data`, called in:
@@ -47,7 +46,7 @@ var lookup_data_bymod = {}
 # Main
 # =============================================================================
 
-# Helper method available to mods
+# Add content via a ContentData resource (.tres file)
 func load_data(mod_data_path: String, mod_name: String = "UnspecifiedAuthor-UnspecifiedModName"):
 	var from_mod_text = ""
 	if mod_name != "":
@@ -64,28 +63,34 @@ func load_data(mod_data_path: String, mod_name: String = "UnspecifiedAuthor-Unsp
 	_add_mod_data(mod_data, mod_name)
 
 
-# Adds missing keys with empty arrays to a provided mod_data dictionary. This
-# allows modders to pass a dictionary with just a single key, eg:
-# `var mod_data_dictionary = { "items": [] }`
+# Add content via a dictionary.
+# Note that you'll need to have created textures from any images on disk (you
+# can use Brotils for this, via `brotils_create_texture_from_image_path`)
+# Supports passing a dictionary with a single key, eg:
+#   var content_data_dictionary = { "items": [] }
 # @since 6.2.0
-func load_data_by_dictionary(mod_data_dict: Dictionary, mod_name: String = "UnspecifiedAuthor-UnspecifiedModName"):
-	var default_keys := [
-		"items",
-		"characters",
-		"weapons",
-		"sets",
-		"challenges",
-		"upgrades",
-		"consumables",
-		"elites",
-		"difficulties",
+func load_data_by_dictionary(content_data_dict: Dictionary, mod_name: String = "UnspecifiedAuthor-UnspecifiedModName"):
+	var valid_keys := [
+		"items",         # ItemData
+		"characters",    # CharacterData
+		"weapons",       # WeaponData
+		"sets",          # SetData
+		"challenges",    # ChallengeData / ExpandedChallengeData
+		"upgrades",      # UpgradeData
+		"consumables",   # ConsumableData
+		"elites",        # Enemydata
+		"difficulties",  # DifficultyData
+		"debug_items",   # ItemData
+		"debug_weapons", # WeaponData
 	]
 
-	for default_key in default_keys:
-		if not mod_data_dict.has(default_key):
-			mod_data_dict[default_key] = []
+	var mod_data = load("res://mods-unpacked/Darkly77-ContentLoader/content_data.gd").new()
 
-	_add_mod_data(mod_data_dict, mod_name)
+	for key in valid_keys:
+		if content_data_dict.has(key):
+			mod_data[key] = content_data_dict[key]
+
+	_add_mod_data(mod_data, mod_name)
 
 
 # Private

--- a/root/mods-unpacked/Darkly77-ContentLoader/content_loader.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/content_loader.gd
@@ -48,7 +48,7 @@ var lookup_data_bymod = {}
 # =============================================================================
 
 # Helper method available to mods
-func load_data(mod_data_path, mod_name:String = "UnspecifiedAuthor-UnspecifiedModName"):
+func load_data(mod_data_path: String, mod_name: String = "UnspecifiedAuthor-UnspecifiedModName"):
 	var from_mod_text = ""
 	if mod_name != "":
 		from_mod_text = " (via "+ mod_name +")"
@@ -61,6 +61,38 @@ func load_data(mod_data_path, mod_name:String = "UnspecifiedAuthor-UnspecifiedMo
 
 	var mod_data = load(mod_data_path)
 
+	_add_mod_data(mod_data)
+
+
+# Adds missing keys with empty arrays to a provided mod_data dictionary. This
+# allows modders to pass a dictionary with just a single key, eg:
+# `var mod_data_dictionary = { "items": [] }`
+# @since 6.2.0
+func load_data_by_dictionary(mod_data_dict: Dictionary, mod_name: String = "UnspecifiedAuthor-UnspecifiedModName"):
+	var default_keys := [
+		"items",
+		"characters",
+		"weapons",
+		"sets",
+		"challenges",
+		"upgrades",
+		"consumables",
+		"elites",
+		"difficulties",
+	]
+
+	for default_key in default_keys:
+		if not mod_data_dict.has(default_key):
+			mod_data_dict[default_key] = []
+
+	_add_mod_data(mod_data_dict)
+
+
+# Private
+# =============================================================================
+
+# Adds mod data to the local variables
+func _add_mod_data(mod_data, mod_name: String = "UnspecifiedAuthor-UnspecifiedModName"):
 	custom_items.append_array(mod_data.items)
 	custom_weapons.append_array(mod_data.weapons)
 	custom_characters.append_array(mod_data.characters)
@@ -86,9 +118,6 @@ func load_data(mod_data_path, mod_name:String = "UnspecifiedAuthor-UnspecifiedMo
 				# for weapon in character.starting_weapons:
 					# ModLoaderUtils.log_debug(str("weapon.my_id -> ", weapon.my_id), CLOADER_LOG)
 
-
-# Private
-# =============================================================================
 
 # Save data to the lookup dictionary
 func _save_to_lookup(mod_data:Resource, mod_name:String = "UnspecifiedAuthor-UnspecifiedModName"):

--- a/root/mods-unpacked/Darkly77-ContentLoader/content_loader.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/content_loader.gd
@@ -93,6 +93,17 @@ func load_data_by_dictionary(content_data_dict: Dictionary, mod_name: String = "
 	_add_mod_data(mod_data, mod_name)
 
 
+# Load content from an instance of ContentData. Mods can't use global classes,
+# so you need to load the class before you create a new instance of it, eg:
+#   var content_data = load("res://mods-unpacked/Darkly77-ContentLoader/content_data.gd").new()
+# Note: There may be an issue with adding things to the empty arrays of a new
+# ContentData instance, and this can cause your content to be added to every
+# array. To fix this, duplicate your empty arrays before adding to them.
+# Search for `debug_items.duplicate` in the code below to see how this is done
+func load_data_by_content_data(content_data, mod_name: String = "UnspecifiedAuthor-UnspecifiedModName"):
+	_add_mod_data(content_data, mod_name)
+
+
 # Private
 # =============================================================================
 

--- a/root/mods-unpacked/Darkly77-ContentLoader/extensions/singletons/debug_service.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/extensions/singletons/debug_service.gd
@@ -1,4 +1,4 @@
-extends "res://singletons/progress_data.gd"
+extends "res://singletons/debug_service.gd"
 
 # We're extending progress_data here because we need the game to finish loading
 # its data before we can add items

--- a/root/mods-unpacked/Darkly77-ContentLoader/extensions/ui/menus/ingame/ingame_main_menu.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/extensions/ui/menus/ingame/ingame_main_menu.gd
@@ -1,0 +1,4 @@
+extends "res://ui/menus/ingame/ingame_main_menu.gd"
+
+func init() -> void:
+	.init()

--- a/root/mods-unpacked/Darkly77-ContentLoader/manifest.json
+++ b/root/mods-unpacked/Darkly77-ContentLoader/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "ContentLoader",
 	"namespace": "Darkly77",
-	"version_number": "6.1.0",
+	"version_number": "6.2.0",
 	"description": "Helper for mods to add new items, weapons, characters and challenges",
 	"website_url": "https://github.com/BrotatoMods/Brotato-ContentLoader",
 	"dependencies": [

--- a/root/mods-unpacked/Darkly77-ContentLoader/mod_main.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/mod_main.gd
@@ -27,8 +27,11 @@ func _ready():
 func _install_extensions(modLoader):
 	# DEFERRED SETUP
 	# This runs ContentLoader._install_data(), but running that func needs to be
-	# deferred until after progress_data has finished setting vanilla things up
-	modLoader.install_script_extension(ext_dir + "singletons/progress_data.gd")
+	# deferred until after progress_data has finished setting vanilla things up.
+	# Note: Originally, this extended progress_data, but was changed to the
+	# last autoload (DebugService/debug_service) to allow other mods to also
+	# wait for ProgressData (or ItemService) to be ready first
+	modLoader.install_script_extension(ext_dir + "singletons/debug_service.gd")
 
 
 # Add ContentLoader as a child of this node (which itself is a child of ModLoader)


### PR DESCRIPTION
Adds 2 new API methods, and makes ContentLoader's main init happen later.

### Delayed Init

ContentLoader now adds its content after Brotato's last autoload (`DebugService`) has initialised, rather than `ProgressData`. This makes it possible for modders to interact with other singletons (eg. `ItemService`) before they add content with ContentLoader.

### API Methods

These new API methods both allow modders to load content data without needing a ContentData resource file. This makes it possible to add content outside of the editor, eg. via another mod's own API.

Note that the data provided to these methods still needs to be in the necessary formats (eg. items should be an instance of `ItemData`, etc).

```gdscript
# Add content via a dictionary.
# Note that you'll need to have created textures from any images on disk (you
# can use Brotils for this, via `brotils_create_texture_from_image_path`)
# Supports passing a dictionary with a single key, eg:
#   var content_data_dictionary = { "items": [] }
func load_data_by_dictionary(content_data_dict: Dictionary, mod_name: String):
```

```gdscript
# Load content from an instance of ContentData. Mods can't use global classes,
# so you need to load the class before you create a new instance of it, eg:
#   var content_data = load("res://mods-unpacked/Darkly77-ContentLoader/content_data.gd").new()
# Note: There may be an issue with adding things to the empty arrays of a new
# ContentData instance, and this can cause your content to be added to every
# array. To fix this, duplicate your empty arrays before adding to them.
# Search for `debug_items.duplicate` in the code below to see how this is done
func load_data_by_content_data(content_data, mod_name: String):
```

### Loading Images

To assist with creating new resources for the 2 new API methods, I have also added a new method to [Brotils](https://github.com/BrotatoMods/Brotato-Brotils) for creating images from disk. See: [`brotils_create_texture_from_image_path`](https://github.com/BrotatoMods/Brotato-Brotils/blob/main/root/mods-unpacked/Darkly77-Brotils/extensions/singletons/utils.gd#L229). 

Brotils is already a dependency for ContentLoader, so this func is now available to anyone using ContentLoader.