### PR TITLE
fix: :bug: fix for game update 1.0.1.3

### DIFF
--- a/root/mods-unpacked/Darkly77-ContentLoader/extensions/singletons/debug_service.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/extensions/singletons/debug_service.gd
@@ -1,9 +1,0 @@
-extends "res://singletons/debug_service.gd"
-
-# We're extending progress_data here because we need the game to finish loading
-# its data before we can add items
-
-func _ready():
-
-	var ContentLoader = get_node("/root/ModLoader/Darkly77-ContentLoader/ContentLoader")
-	ContentLoader._install_data()

--- a/root/mods-unpacked/Darkly77-ContentLoader/extensions/singletons/utils.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/extensions/singletons/utils.gd
@@ -1,0 +1,6 @@
+extends "res://singletons/utils.gd"
+
+
+func _ready():
+	var ContentLoader = get_node("/root/ModLoader/Darkly77-ContentLoader/ContentLoader")
+	ContentLoader._install_data()

--- a/root/mods-unpacked/Darkly77-ContentLoader/extensions/ui/menus/ingame/ingame_main_menu.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/extensions/ui/menus/ingame/ingame_main_menu.gd
@@ -1,4 +1,0 @@
-extends "res://ui/menus/ingame/ingame_main_menu.gd"
-
-func init() -> void:
-	.init()

--- a/root/mods-unpacked/Darkly77-ContentLoader/manifest.json
+++ b/root/mods-unpacked/Darkly77-ContentLoader/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "ContentLoader",
 	"namespace": "Darkly77",
-	"version_number": "6.2.1",
+	"version_number": "6.2.2",
 	"description": "Helper for mods to add new items, weapons, characters and challenges",
 	"website_url": "https://github.com/BrotatoMods/Brotato-ContentLoader",
 	"dependencies": [
@@ -9,15 +9,34 @@
 	],
 	"extra": {
 		"godot": {
-			"incompatibilities": [],
 			"authors": [
 				"Darkly77",
 				"dami",
 				"KANA"
 			],
-			"compatible_mod_loader_version": ["4.1.0"],
-			"compatible_game_version": ["0.8.0.3"],
-			"config_defaults": {}
+			"optional_dependencies": [
+
+			],
+			"compatible_game_version": [
+				"1.0.1.3"
+			],
+			"compatible_mod_loader_version": [
+				"6.2.0"
+			],
+			"incompatibilities": [
+
+			],
+			"load_before": [
+
+			],
+			"tags": [
+
+			],
+			"config_schema": {
+
+			},
+			"description_rich": "",
+			"image": null
 		}
 	}
 }

--- a/root/mods-unpacked/Darkly77-ContentLoader/mod_main.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/mod_main.gd
@@ -8,13 +8,13 @@ var ext_dir = ""
 # Main
 # =============================================================================
 
-func _init(modLoader = ModLoader):
+func _init():
 	ModLoaderLog.info("Init", CLOADER_LOG)
 	dir = ModLoaderMod.get_unpacked_dir() + "Darkly77-ContentLoader/"
 	ext_dir = dir + "extensions/"
 
 	_add_child_class()
-	_install_extensions(modLoader)
+	install_script_extensions()
 
 
 func _ready():
@@ -24,14 +24,19 @@ func _ready():
 # Custom
 # =============================================================================
 
-func _install_extensions(modLoader):
+func install_script_extensions():
 	# DEFERRED SETUP
 	# This runs ContentLoader._install_data(), but running that func needs to be
 	# deferred until after progress_data has finished setting vanilla things up.
 	# Note: Originally, this extended progress_data, but was changed to the
 	# last autoload (DebugService/debug_service) to allow other mods to also
 	# wait for ProgressData (or ItemService) to be ready first
-	ModLoaderMod.install_script_extension(ext_dir + "singletons/debug_service.gd")
+	# UPDATE 6.2.2: Changed it to call ContentLoader._install_data() in
+	# Utils, so ItemService is populated with all modded data before ProgressData
+	# deserializes the save data. With Brotato Patch 1.0.1.3, the function
+	# cache_effect_hashes was introduced to ProgressData and causes an error if
+	# the modded data is not available in ItemService.
+	ModLoaderMod.install_script_extension("res://mods-unpacked/Darkly77-ContentLoader/extensions/singletons/utils.gd")
 
 
 # Add ContentLoader as a child of this node (which itself is a child of ModLoader)


### PR DESCRIPTION
moved `ContentLoader._install_data()` call to `utils.gd` extension.

Possible breaks mods that add their custom data not in their `mod_main` `_ready()` function.