### PR TITLE
fix: :bug: progress data loading

### DIFF
--- a/root/mods-unpacked/Darkly77-ContentLoader/extensions/singletons/item_service.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/extensions/singletons/item_service.gd
@@ -1,0 +1,6 @@
+extends "res://singletons/item_service.gd"
+
+
+func _ready() -> void:
+	var content_loader = get_node("/root/ModLoader/Darkly77-ContentLoader/ContentLoader")
+	content_loader._install_data()

--- a/root/mods-unpacked/Darkly77-ContentLoader/extensions/singletons/utils.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/extensions/singletons/utils.gd
@@ -1,6 +1,0 @@
-extends "res://singletons/utils.gd"
-
-
-func _ready():
-	var ContentLoader = get_node("/root/ModLoader/Darkly77-ContentLoader/ContentLoader")
-	ContentLoader._install_data()

--- a/root/mods-unpacked/Darkly77-ContentLoader/manifest.json
+++ b/root/mods-unpacked/Darkly77-ContentLoader/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "ContentLoader",
 	"namespace": "Darkly77",
-	"version_number": "6.2.2",
+	"version_number": "6.2.3",
 	"description": "Helper for mods to add new items, weapons, characters and challenges",
 	"website_url": "https://github.com/BrotatoMods/Brotato-ContentLoader",
 	"dependencies": [
@@ -18,7 +18,7 @@
 
 			],
 			"compatible_game_version": [
-				"1.1.4.0"
+				"1.1.13.1"
 			],
 			"compatible_mod_loader_version": [
 				"6.2.0"

--- a/root/mods-unpacked/Darkly77-ContentLoader/mod_main.gd
+++ b/root/mods-unpacked/Darkly77-ContentLoader/mod_main.gd
@@ -36,7 +36,12 @@ func install_script_extensions():
 	# deserializes the save data. With Brotato Patch 1.0.1.3, the function
 	# cache_effect_hashes was introduced to ProgressData and causes an error if
 	# the modded data is not available in ItemService.
-	ModLoaderMod.install_script_extension("res://mods-unpacked/Darkly77-ContentLoader/extensions/singletons/utils.gd")
+	# UPDATE 6.2.3: Changed this again, Utils has been moved above ProgressData.
+	# This causes modded content progress data to not be loaded correctly.
+	# (max_difficulty_beaten gets deleted)
+	# Moved the ContentLoader._install_data() to ItemService._ready()
+
+	ModLoaderMod.install_script_extension("res://mods-unpacked/Darkly77-ContentLoader/extensions/singletons/item_service.gd")
 
 
 # Add ContentLoader as a child of this node (which itself is a child of ModLoader)


### PR DESCRIPTION
Moved the ContentLoader._install_data() to ItemService._ready(). Utils has been moved above ProgressData. This causes modded content progress data to not be loaded correctly.